### PR TITLE
Add support for disable_controller and force_platform, use PM multi-arch file naming for the binary, add build tags in binary (date, git)

### DIFF
--- a/Makefile.gmloader
+++ b/Makefile.gmloader
@@ -5,6 +5,16 @@ CXX := ${CROSS}g++
 LD := ${CROSS}ld
 PKG_CONFIG := ${CROSS}pkg-config
 
+BUILD_DATE = $(shell date +"%Y%m%d_%H%M%S")
+GIT_HASH = $(shell git rev-parse HEAD)
+GIT_BRANCH = $(shell git branch --show-current)
+
+DEVICE_ARCH = aarch64
+
+ifeq ($(ARCH), armhf-linux-gnu)
+	DEVICE_ARCH = armhf
+endif
+
 LIBS=\
 	-pthread \
 	-lm \
@@ -18,7 +28,7 @@ OPTM?=-Os
 COMMONFLAGS=-Wno-strict-aliasing -Werror=return-type -I. -I./thunks/ -I./loader/ -I./gmloader/ -I./build/${ARCH}/thunks/libc -I./jni/ -I./3rdparty/json/include ${OPTM} -MMD
 CFLAGS=$(shell ${PKG_CONFIG} sdl2 --cflags) ${COMMONFLAGS}
 CXXFLAGS=-std=gnu++2a -fuse-cxa-atexit $(shell ${PKG_CONFIG} sdl2 --cflags) ${COMMONFLAGS}
-LDFLAGS=-L3rdparty/libbsd/src/.libs ${OPTM}
+LDFLAGS=-L3rdparty/libbsd/src/.libs ${OPTM} -Wl,--defsym,BUILD_DATE_$(BUILD_DATE)=0 -Wl,--defsym,GIT_HASH_$(GIT_HASH)=0 -Wl,--defsym,GIT_BRANCH_$(GIT_BRANCH)=0
 
 # General pre-processing flags
 LLVM_FILE?=
@@ -50,7 +60,7 @@ GENERIC_OBJ:=\
 
 OBJ=$(patsubst build/%,build/${ARCH}/%,${GENERIC_OBJ})
 
-all: build/${ARCH}/gmloader/gmloader
+all: build/${ARCH}/gmloader/gmloadernext.${DEVICE_ARCH}
 
 clean:
 	rm -rf build/${ARCH}
@@ -60,7 +70,7 @@ clean:
 
 # By repeating the generated headers on this rule, we force them to start building
 # as soon as possible, so libc_table.cpp isn't waiting forever.
-build/${ARCH}/gmloader/gmloader: ${LIBC_TABS} $(BSD_OBJ) $(OBJ)
+build/${ARCH}/gmloader/gmloadernext.${DEVICE_ARCH}: ${LIBC_TABS} $(BSD_OBJ) $(OBJ)
 	$(CXX) $(LDFLAGS) -o $@ $(OBJ) $(BSD_OBJ) $(LIBS)
 
 build/${ARCH}/%.cpp.o: %.cpp

--- a/Makefile.gmloader
+++ b/Makefile.gmloader
@@ -11,7 +11,7 @@ GIT_BRANCH = $(shell git branch --show-current)
 
 DEVICE_ARCH = aarch64
 
-ifeq ($(ARCH), armhf-linux-gnu)
+ifeq ($(ARCH), arm-linux-gnueabihf)
 	DEVICE_ARCH = armhf
 endif
 

--- a/Makefile.gmloader
+++ b/Makefile.gmloader
@@ -60,7 +60,7 @@ GENERIC_OBJ:=\
 
 OBJ=$(patsubst build/%,build/${ARCH}/%,${GENERIC_OBJ})
 
-all: build/${ARCH}/gmloader/gmloadernext.${DEVICE_ARCH}
+all: build/${ARCH}/gmloader/gmloader.${DEVICE_ARCH}
 
 clean:
 	rm -rf build/${ARCH}
@@ -70,7 +70,7 @@ clean:
 
 # By repeating the generated headers on this rule, we force them to start building
 # as soon as possible, so libc_table.cpp isn't waiting forever.
-build/${ARCH}/gmloader/gmloadernext.${DEVICE_ARCH}: ${LIBC_TABS} $(BSD_OBJ) $(OBJ)
+build/${ARCH}/gmloader/gmloader.${DEVICE_ARCH}: ${LIBC_TABS} $(BSD_OBJ) $(OBJ)
 	$(CXX) $(LDFLAGS) -o $@ $(OBJ) $(BSD_OBJ) $(LIBS)
 
 build/${ARCH}/%.cpp.o: %.cpp

--- a/README.md
+++ b/README.md
@@ -56,17 +56,22 @@ gmloadernext can load a json formatted configuration file using the `-c` option.
 {
     "save_dir" : "gamedata",
     "apk_path" : "my_game.apk",
-    "show_cursor": false
+    "show_cursor" : false,
+    "disable_controller" : false,
+    "force_platform" : "os_windows"
 }
 ```
 
 When no configuration file is present the default values are:
 
-| Parameter name | Default value |
-|----------------|---------------|
-| save_dir       | ./            |
-| apk_path       | game.apk      |
-| show_cursor    | true          |
+| Parameter name     | Default value |
+|--------------------|---------------|
+| save_dir           | ./            |
+| apk_path           | game.apk      |
+| show_cursor        | true          |
+| disable_controller | false         |
+| force_platform     | os_android    |
+
 
 ### License:
 -----

--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ When no configuration file is present the default values are:
 | disable_controller | false         |
 | force_platform     | os_android    |
 
+Supported values for force_platform are:
+- os_unknown
+- os_windows
+- os_macosx
+- os_ios
+- os_android
+- os_linux
+- os_psvita
+- os_ps4
+- os_xboxone
+- os_tvos
+- os_switch
 
 ### License:
 -----

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ For this to be possible, you must extract the libraries from the APK into the ap
 
 ### Config file
 -----
-gmloadernext can load a json formatted configuration file using the `-c` option. For exemple `gmloadernext -c configuration.gmld`
+gmloadernext can load a json formatted configuration file using the `-c` option. For exemple `./gmloader.aarch64 -c gmloader.conf`
 
-**configuration.gmld**:
+**gmloader.conf**:
 ```json
 {
     "save_dir" : "gamedata",

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Corrections, fixes, issue reports and optimizations are always welcome.
 
 `git clone <repository url> --recursive`
 
-- `ARCH`: Specify the architecture, e.g.: `aarch64-linux-gnu`
+- `ARCH`: Specify the architecture, e.g.: `aarch64-linux-gnu` or `arm-linux-gnueabihf`
 - `LLVM_FILE`: Specify the LLVM Clang library file, e.g.: `/usr/lib/llvm-9/lib/libclang-9.so.1` for clang-9.
 - `LLVM_INC`: Specify the path for LLVM includes for your architecture, e.g.: `aarch64-linux-gnu`.
 - `OPTM`: Specify the optimization flags, e.g.: `-O3`, `-Os` or `-Og -ggdb`.

--- a/configuration.gmld
+++ b/configuration.gmld
@@ -1,5 +1,7 @@
 {
     "save_dir" : "gamedata",
     "apk_path" : "my_game.apk",
-    "show_cursor": true
+    "show_cursor" : false,
+    "disable_controller" : false,
+    "force_platform" : "os_windows"
 }

--- a/gmloader.conf.example
+++ b/gmloader.conf.example
@@ -3,5 +3,5 @@
     "apk_path" : "my_game.apk",
     "show_cursor" : false,
     "disable_controller" : false,
-    "force_platform" : "os_windows"
+    "force_platform" : "os_wind0ws"
 }

--- a/gmloader/configuration.cpp
+++ b/gmloader/configuration.cpp
@@ -8,6 +8,8 @@ void init_config(){
     gmloader_config.apk_path = "game.apk";
     gmloader_config.save_dir = "";
     gmloader_config.show_cursor = true;
+    gmloader_config.disable_controller = false;
+    gmloader_config.force_platform = "os_android";
 }
 
 int read_config_file(const char* path){
@@ -55,6 +57,26 @@ int read_config_file(const char* path){
     }
     printf("\tshow_cursor = %d\n",gmloader_config.show_cursor);
 
+    try{
+        config_json.at("disable_controller").get_to(gmloader_config.disable_controller);
+        p_loaded++;
+    }catch (const json::out_of_range& e){
+        // default value
+    }catch (const json::type_error& e){
+        warning("\tdisable_controller type error\n");
+    }
+    printf("\tdisable_controller = %d\n",gmloader_config.disable_controller);
+
+    try{
+        config_json.at("force_platform").get_to(gmloader_config.force_platform);
+        p_loaded++;
+    }catch (const json::out_of_range& e){
+        // default value
+    }catch (const json::type_error& e){
+        warning("\tforce_platform type error\n");
+    }
+    printf("\tforce_platform = %s\n",gmloader_config.force_platform.c_str());
+
     return p_loaded;
 }
 
@@ -62,6 +84,8 @@ void show_config(){
     printf("config: save_dir = %s\n",gmloader_config.save_dir.c_str());
     printf("config: apk_path = %s\n",gmloader_config.apk_path.c_str());
     printf("config: show_cursor = %d\n",gmloader_config.show_cursor);
+    printf("config: disable_controller = %d\n",gmloader_config.disable_controller);
+    printf("config: force_platform = %s\n",gmloader_config.force_platform.c_str());
 }
 
 fs::path get_absolute_path(const char* path, fs::path work_dir){

--- a/gmloader/configuration.h
+++ b/gmloader/configuration.h
@@ -11,6 +11,8 @@ namespace gmloader {
         std::string save_dir;
         std::string apk_path;
         bool show_cursor;
+        bool disable_controller;
+        std::string force_platform;
     };
 }
 

--- a/gmloader/input.cpp
+++ b/gmloader/input.cpp
@@ -6,6 +6,7 @@
 #include "platform.h"
 #include "so_util.h"
 #include "libyoyo.h"
+#include "configuration.h"
 
 int app_in_focus = 0;
 int mouse_has_warped = 0;
@@ -26,6 +27,8 @@ static controller_t sdl_controllers[8] = {
     {.controller = NULL, .which = -1, .slot = -1},
     {.controller = NULL, .which = -1, .slot = -1}
 };
+
+extern gmloader::config gmloader_config;
 
 static int get_free_controller_slot()
 {
@@ -228,6 +231,11 @@ int update_inputs(SDL_Window *win)
     while (SDL_PollEvent(&ev)) {
         switch (ev.type) {
         case SDL_CONTROLLERDEVICEADDED:
+            if(gmloader_config.disable_controller == 1){
+                printf("Controller %d ignored (disable_controller = True)\n", ev.cdevice.which);
+                break;
+            }
+
             // For this event, ev.cdevice.which refers to the Active device index.
             if (SDL_IsGameController(ev.cdevice.which)) {
                 int slot = get_free_controller_slot();

--- a/gmloader/libyoyo.cpp
+++ b/gmloader/libyoyo.cpp
@@ -87,7 +87,7 @@ static const char *fake_functs[] = {
     "psn_user_for_pad"
 };
 
-double FORCE_PLATFORM;
+double FORCE_PLATFORM = os_android;
 
 ABI_ATTR int _dbg_csol_print(void *csol, const char *fmt, ...) {
     char csol_str[2048];

--- a/gmloader/libyoyo.cpp
+++ b/gmloader/libyoyo.cpp
@@ -87,6 +87,8 @@ static const char *fake_functs[] = {
     "psn_user_for_pad"
 };
 
+double FORCE_PLATFORM;
+
 ABI_ATTR int _dbg_csol_print(void *csol, const char *fmt, ...) {
     char csol_str[2048];
     va_list list;
@@ -119,7 +121,6 @@ ABI_ATTR static void game_end_reimpl(RValue *ret, void *self, void *other, int a
     *New_Room = 0xffffff9c;
 }
 
-double FORCE_PLATFORM = os_android;
 ABI_ATTR static double force_platform_type()
 {
     return FORCE_PLATFORM;

--- a/gmloader/libyoyo.h
+++ b/gmloader/libyoyo.h
@@ -119,10 +119,22 @@ typedef struct LLVMVars {
     void *pYYStackTrace;
 } LLVMVars;
 
+// OS values
+// https://manual.gamemaker.io/monthly/en/GameMaker_Language/GML_Reference/OS_And_Compiler/os_type.htm
+// https://github.com/UnderminersTeam/UndertaleModTool/blob/caf04126f273b57bb2200b8739bb9d57e25d8f92/UndertaleModLib/Compiler/BuiltinList.cs#L3165
+// os_gxgames is unknown
+// os_ps5 value is unknown
+#define os_unknown    ((double)(-1.0f));
 #define os_windows    ((double)(0.0f))
+#define os_macosx     ((double)(1.0f))
+#define os_ios        ((double)(3.0f))
 #define os_android    ((double)(4.0f))
 #define os_linux      ((double)(6.0f))
 #define os_psvita     ((double)(12.0f))
+#define os_ps4        ((double)(14.0f))
+#define os_xboxone    ((double)(15.0f))
+#define os_tvos       ((double)(20.0f))
+#define os_switch     ((double)(21.0f))
 #define gp_face1      ((double)(32769.0f))
 #define gp_face2      ((double)(32770.0f))
 #define gp_face3      ((double)(32771.0f))

--- a/gmloader/main.cpp
+++ b/gmloader/main.cpp
@@ -35,6 +35,7 @@ extern DynLibFunction symtable_zlib[];
 extern DynLibFunction symtable_gles2[];
 
 extern gmloader::config gmloader_config;
+extern double FORCE_PLATFORM;
 
 DynLibFunction *so_static_patches[32] = {
     NULL,
@@ -107,6 +108,20 @@ int main(int argc, char *argv[])
             warning("Error while loading the config file\n");
         }
 
+    }
+
+    if(strcmp(gmloader_config.force_platform.c_str(), "os_android") == 0){
+        FORCE_PLATFORM = os_android;
+        printf("os_type = os_android\n");
+    }else if(strcmp(gmloader_config.force_platform.c_str(), "os_linux") == 0){
+        FORCE_PLATFORM = os_linux;
+        printf("os_type = os_linux\n");
+    }else if(strcmp(gmloader_config.force_platform.c_str(), "os_windows") == 0){
+        FORCE_PLATFORM = os_windows;
+        printf("os_type = os_windows\n");
+    }else if(strcmp(gmloader_config.force_platform.c_str(), "os_psvita") == 0){
+        FORCE_PLATFORM = os_psvita;
+        printf("os_type = os_psvita\n");
     }
 
     save_dir = get_absolute_path(gmloader_config.save_dir.c_str(), work_dir) / "";

--- a/gmloader/main.cpp
+++ b/gmloader/main.cpp
@@ -111,8 +111,7 @@ int main(int argc, char *argv[])
     }
 
     char platform_ov[32];
-    strncpy(platform_ov,gmloader_config.force_platform.c_str(),sizeof(platform_ov)-1);
-    platform_ov[31] = '\0';
+    strncpy(platform_ov,gmloader_config.force_platform.c_str(),sizeof(platform_ov));
     
     if (platform_ov) {
         for (int i = 0; platform_ov[i] != '\0'; i++)
@@ -141,8 +140,9 @@ int main(int argc, char *argv[])
         }else if(strcmp(platform_ov, "os_switch") == 0){
             FORCE_PLATFORM = os_switch;
         }else{
-            fatal_error("Unexpected platform '%s'.\n", platform_ov);
+            warning("Unexpected platform '%s'.\n", platform_ov);
             strcpy(platform_ov,"os_unknown");
+            FORCE_PLATFORM = os_unknown;
         }
 
         printf("os_type = %s\n", platform_ov);
@@ -208,7 +208,7 @@ int main(int argc, char *argv[])
     if (ms_freq != NULL)
     {
         // Patch the default samplerate to something reasonable
-        *ms_freq = 44100;
+        *ms_freq = 48000;
     }
 
     String *apk_path_arg = (String *)env->NewStringUTF(apk_path.c_str());

--- a/gmloader/main.cpp
+++ b/gmloader/main.cpp
@@ -110,18 +110,43 @@ int main(int argc, char *argv[])
 
     }
 
-    if(strcmp(gmloader_config.force_platform.c_str(), "os_android") == 0){
-        FORCE_PLATFORM = os_android;
-        printf("os_type = os_android\n");
-    }else if(strcmp(gmloader_config.force_platform.c_str(), "os_linux") == 0){
-        FORCE_PLATFORM = os_linux;
-        printf("os_type = os_linux\n");
-    }else if(strcmp(gmloader_config.force_platform.c_str(), "os_windows") == 0){
-        FORCE_PLATFORM = os_windows;
-        printf("os_type = os_windows\n");
-    }else if(strcmp(gmloader_config.force_platform.c_str(), "os_psvita") == 0){
-        FORCE_PLATFORM = os_psvita;
-        printf("os_type = os_psvita\n");
+    char platform_ov[32];
+    strncpy(platform_ov,gmloader_config.force_platform.c_str(),sizeof(platform_ov)-1);
+    platform_ov[31] = '\0';
+    
+    if (platform_ov) {
+        for (int i = 0; platform_ov[i] != '\0'; i++)
+            platform_ov[i] = tolower(platform_ov[i]);
+
+        if(strcmp(platform_ov, "os_unknown") == 0){
+            FORCE_PLATFORM = os_unknown;
+        }else if(strcmp(platform_ov, "os_windows") == 0){
+            FORCE_PLATFORM = os_windows;
+        }else if(strcmp(platform_ov, "os_macosx") == 0){
+            FORCE_PLATFORM = os_macosx;
+        }else if(strcmp(platform_ov, "os_ios") == 0){
+            FORCE_PLATFORM = os_ios;
+        }else if(strcmp(platform_ov, "os_android") == 0){
+            FORCE_PLATFORM = os_android;
+        }else if(strcmp(platform_ov, "os_linux") == 0){
+            FORCE_PLATFORM = os_linux;
+        }else if(strcmp(platform_ov, "os_psvita") == 0){
+            FORCE_PLATFORM = os_psvita;
+        }else if(strcmp(platform_ov, "os_ps4") == 0){
+            FORCE_PLATFORM = os_ps4;
+        }else if(strcmp(platform_ov, "os_xboxone") == 0){
+            FORCE_PLATFORM = os_xboxone;
+        }else if(strcmp(platform_ov, "os_tvos") == 0){
+            FORCE_PLATFORM = os_tvos;
+        }else if(strcmp(platform_ov, "os_switch") == 0){
+            FORCE_PLATFORM = os_switch;
+        }else{
+            fatal_error("Unexpected platform '%s'.\n", platform_ov);
+            strcpy(platform_ov,"os_unknown");
+        }
+
+        printf("os_type = %s\n", platform_ov);
+
     }
 
     save_dir = get_absolute_path(gmloader_config.save_dir.c_str(), work_dir) / "";


### PR DESCRIPTION
Supported values for `disable_controller` are `true` and `false` (default)

Supported values for `force_platform` are:
- `os_unknown`
- `os_windows`
- `os_macosx`
- `os_ios`
- `os_android` (default)
- `os_linux`
- `os_psvita`
- `os_ps4`
- `os_xboxone`
- `os_tvos`
- `os_switch`

Binaries will be named `gmloadernext.aarch64` and `gmloadernext.armhf`

Build tags can be checked this way:
```bash
root@9118ae47a15f:/devel/gmloader-next# strings build/aarch64-linux-gnu/gmloader/gmloadernext.aarch64 | grep -E  "(GIT_|BUILD_)"
GIT_HASH_3aeaec44a2283c11b630758476cdef274c2a0a5a
GIT_BRANCH_master
BUILD_DATE_20241104_110957
```