### PR TITLE
Introduce automated arm64 & armhf Github Actions builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+name: gmloader-Next Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "master" ]
+    paths-ignore:
+      - '**/README.md'
+  pull_request:
+    branches: [ "master" ]
+    paths-ignore:
+      - '**/README.md'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: debian:bullseye
+    name: Debian ${{ matrix.arch.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: 
+          - name: arm64
+            cross: aarch64-linux-gnu
+            executable: aarch64
+          - name: armhf
+            cross: arm-linux-gnueabihf
+            executable: armhf
+
+    steps:
+      - name: Install ${{ matrix.arch.name }} dependencies
+        run: |
+          dpkg --add-architecture ${{ matrix.arch.name }}
+          apt update
+          apt install -y --no-install-recommends python3 git dpkg-dev build-essential binutils python3-clang binutils-${{ matrix.arch.cross }} libstdc++-10-dev-${{ matrix.arch.name }}-cross linux-libc-dev-${{ matrix.arch.name }}-cross make linux-libc-dev-${{ matrix.arch.name }}-cross linux-libc-dev-${{ matrix.arch.name }}-cross gcc-${{ matrix.arch.cross }} g++-${{ matrix.arch.cross }} libsdl2-dev:${{ matrix.arch.name }} libzip-dev:${{ matrix.arch.name }} ca-certificates
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Build ${{ matrix.arch.name }}
+        run: make -f Makefile.gmloader ARCH=${{ matrix.arch.cross }} LLVM_FILE=/usr/lib/llvm-11/lib/libclang-11.so LLVM_INC=/usr/${{ matrix.arch.cross }}/include/c++/10/${{ matrix.arch.cross }} -j$(nproc)
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: gmloader_${{ matrix.arch.name }}
+          path: ${{ github.workspace }}/build/${{ matrix.arch.cross }}/gmloader/gmloader.${{ matrix.arch.executable}}


### PR DESCRIPTION
The resulting `gmloader.{arch}` executable is packaged and uploaded to a GitHub artifact.

Closes #3  

@JeodC 