### PR TITLE
Add game_change

### DIFF
--- a/gmloader/gameframe.cpp
+++ b/gmloader/gameframe.cpp
@@ -1,7 +1,6 @@
 #include "platform.h"
 #include "so_util.h"
 #include "libyoyo.h"
-#include "configuration.h"
 
 static const char* gameframe_stubs[] = {
     "gameframe_mouse_in_window_raw",

--- a/gmloader/input.cpp
+++ b/gmloader/input.cpp
@@ -6,7 +6,6 @@
 #include "platform.h"
 #include "so_util.h"
 #include "libyoyo.h"
-#include "configuration.h"
 
 int app_in_focus = 0;
 int mouse_has_warped = 0;

--- a/gmloader/libyoyo.cpp
+++ b/gmloader/libyoyo.cpp
@@ -1,5 +1,8 @@
 #include <stdio.h>
 #include <stdarg.h>
+#include <string.h>
+#include <string>
+#include <stdlib.h>
 
 #include "platform.h"
 #include "so_util.h"
@@ -176,6 +179,60 @@ ABI_ATTR static void window_handle(RValue *ret, void *self, void *other, int arg
     ret->rvalue.v64 = 0;
 }
 
+// Implementation of game_change which is not available for android normally
+ // Takes two arguments: work_dir and launch_params (example: "/chapter1_windows" "-game data.win")
+ // https://manual.gamemaker.io/beta/en/GameMaker_Language/GML_Reference/General_Game_Control/game_change.htm
+ABI_ATTR void game_change_reimpl(RValue *ret, void *self, void *other, int argc, RValue *args) {
+    char buffer[1024];
+    int len = snprintf(buffer, sizeof(buffer), "game_change(): ");
+    for (int i = 0; i < argc && len < sizeof(buffer); i++) {
+        const char *arg = (args[i].kind == VALUE_STRING && args[i].rvalue.str && args[i].rvalue.str->m_thing)
+                          ? (char*)args[i].rvalue.str->m_thing
+                          : "INVALID";
+        len += snprintf(buffer + len, sizeof(buffer) - len, "%s%s", i > 0 ? ", " : "", arg);
+    }
+    warning("%s\n", buffer);
+
+    if (ret) {
+        ret->kind = VALUE_BOOL;
+        ret->rvalue.val = 0;
+    }
+
+    if (argc < 2) {
+        warning("game_change(): Requires at least two arguments (workdir and params)\n");
+        return;
+    }
+
+    for (int i = 0; i < argc; i++) {
+        if (args[i].kind != VALUE_STRING || !args[i].rvalue.str || !args[i].rvalue.str->m_thing) {
+            warning("game_change(): Argument %d is not a valid string\n", i);
+            return;
+        }
+    }
+
+    const char *workdir = static_cast<const char*>(args[0].rvalue.str->m_thing);
+    gc_workdir = strdup(workdir);
+    if (!gc_workdir) {
+        warning("game_change(): Failed to duplicate workdir\n");
+        return;
+    }
+
+    std::string sub_path = gc_workdir;
+    if (!sub_path.empty() && sub_path.back() != '/') {
+        sub_path += '/';
+    }
+
+    std::string full_path = gmloader_config.save_dir + sub_path;
+    warning("game_change(): Resolved game path: '%s'\n", full_path.c_str());
+
+    relaunch_flag = 1;
+
+    if (ret) {
+        ret->kind = VALUE_BOOL;
+        ret->rvalue.val = 1;
+    }
+}
+
 void patch_libyoyo(so_module *mod)
 {
     // Load all of the native symbols referenced
@@ -276,6 +333,7 @@ void patch_libyoyo(so_module *mod)
     }
 
     Function_Add("window_handle", window_handle, 0, 1);
+    Function_Add("game_change", game_change_reimpl, 2, 0);
 
     so_symbol_fix_ldmia(mod, "_Z11Shader_LoadPhjS_");
 }

--- a/gmloader/libyoyo.h
+++ b/gmloader/libyoyo.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "configuration.h"
+
 #define MASK_KIND_RVALUE 0x0ffffff
 typedef enum RValueType {
 	VALUE_REAL = 0,
@@ -277,6 +279,9 @@ extern void **g_nYYCode;
 extern void **g_pGameFileBuffer;
 extern void **g_ppYYStackTrace;
 extern int *Extension_Main_number;
+
+extern const char *gc_workdir;
+extern int relaunch_flag;
 
 extern void patch_libyoyo(struct so_module *mod);
 extern void patch_input(struct so_module *mod);

--- a/gmloader/main.cpp
+++ b/gmloader/main.cpp
@@ -1,6 +1,8 @@
 #include <SDL2/SDL.h>
 #include <stdio.h>
+#include <string.h>
 #include <signal.h>
+#include <unistd.h>
 #include <zip.h>
 
 #include "platform.h"
@@ -11,8 +13,12 @@
 #include "classes/RunnerJNILib.h"
 #include "khronos/gles2.h"
 #include "libyoyo.h"
-#include "configuration.h"
 #include "texture.h"
+
+
+int relaunch_flag = 0;
+char *program_name = nullptr;
+const char* gc_workdir = nullptr;
 
 /*
       Don't touch this incantation. It serves no practical
@@ -103,25 +109,45 @@ static fs::path get_absolute_path(const char* path, fs::path work_dir){
 
 int main(int argc, char *argv[])
 {
+    // Store the program name from argv[0]
+    if (argc > 0 && argv[0]) {
+        program_name = argv[0];
+    } else 
+    {
+        fatal_error("Main: Could not determine program name from argv[0]\n");
+        return -1;
+    }
+
     gmloader_config.init_defaults();
 
     fs::path work_dir, config_file_path, save_dir, apk_path;
     work_dir = fs::canonical(fs::current_path()) / "";
 
-    if (argc > 2 && strcmp(argv[1], "-c") == 0) {
-        
-        config_file_path = work_dir / argv[2];
-
-        if(gmloader_config.parse_file(config_file_path.c_str()) < 0 ){
-            warning("Error while loading the config file\n");
+    // Check for -a (apk_path override) and -c (config file)
+    std::string override_apk_path;
+    for (int i = 1; i < argc; ++i) {
+        if (strcmp(argv[i], "-a") == 0 && i + 1 < argc) {
+            override_apk_path = argv[i + 1];
+            warning("Main: Using apk_path override from args: '%s'\n", override_apk_path.c_str());
+            i++; // Skip the value
         }
+        else if (strcmp(argv[i], "-c") == 0 && i + 1 < argc) {
+            config_file_path = work_dir / argv[i + 1];
+            if (gmloader_config.parse_file(config_file_path.c_str()) < 0) {
+                warning("Error while loading the config file\n");
+            }
+        }
+    }
 
+    // Apply apk_path override if provided
+    if (!override_apk_path.empty()) {
+        gmloader_config.apk_path = override_apk_path;
     }
 
     char platform_ov[32];
     strncpy(platform_ov, gmloader_config.force_platform.c_str(), sizeof(platform_ov) - 1);
     platform_ov[sizeof(platform_ov) - 1] = '\0';
-    
+
     std::unordered_map<std::string, int> platform_map = {
         {"os_unknown", os_unknown},
         {"os_windows", os_windows},
@@ -274,7 +300,7 @@ int main(int argc, char *argv[])
     RunnerJNILib::Startup(env, 0, apk_path_arg, save_dir_arg, pkg_dir_arg, 4, 0);
     setup_ended = 1;
     
-    while (cont != 0 && cont != 2 && RunnerJNILib_MoveTaskToBackCalled == 0) {
+    while (cont != 0 && cont != 2 && RunnerJNILib_MoveTaskToBackCalled == 0 && relaunch_flag == 0) {
         if (update_inputs(sdl_win) != 1)
             break;
         SDL_GetWindowSize(sdl_win, &w, &h);
@@ -286,6 +312,63 @@ int main(int argc, char *argv[])
     SDL_GL_DeleteContext(sdl_ctx);
     SDL_DestroyWindow(sdl_win);
     SDL_Quit();
+
+    // Check for relaunch
+    if (relaunch_flag && gc_workdir) {
+        warning("Main: Relaunch triggered. workdir='%s'\n", gc_workdir);
+
+        // Extract subfolder prefix from original apk_path (e.g., "assets/")
+        std::string orig_apk_path = gmloader_config.apk_path;
+        std::string prefix;
+        size_t last_slash = orig_apk_path.find_last_of('/');
+        if (last_slash != std::string::npos) {
+            prefix = orig_apk_path.substr(0, last_slash + 1); // Include the slash
+        }
+
+        // Remove leading and trailing slashes from gc_workdir (may or may not have any)
+        std::string workdir_clean = gc_workdir;
+        if (!workdir_clean.empty() && workdir_clean.front() == '/')
+            workdir_clean = workdir_clean.substr(1);
+        if (!workdir_clean.empty() && workdir_clean.back() == '/')
+            workdir_clean = workdir_clean.substr(0, workdir_clean.length() - 1);
+        std::string new_apk_path = prefix + workdir_clean;
+
+        // Check if the override is valid
+        bool use_override = (new_apk_path.find("..") == std::string::npos && !workdir_clean.empty());
+        if (use_override) {
+            gmloader_config.apk_path = new_apk_path;
+            warning("Main: Updated config: apk_path='%s', save_dir='%s'\n", 
+                    gmloader_config.apk_path.c_str(), gmloader_config.save_dir.c_str());
+        } else {
+            warning("Main: Ignoring override='%s' (workdir='%s'), using original apk_path='%s'\n", 
+                    new_apk_path.c_str(), gc_workdir, gmloader_config.apk_path.c_str());
+        }
+
+        // Relaunch: use -a only if override is valid, otherwise just -c
+        char apk_path_arg[1024];
+        char config_path_arg[1024];
+        char *argv_relaunch[6];
+        int arg_count = 0;
+        argv_relaunch[arg_count++] = program_name;
+        argv_relaunch[arg_count++] = (char*)"-c";
+        snprintf(config_path_arg, sizeof(config_path_arg), "%s", config_file_path.c_str());
+        argv_relaunch[arg_count++] = config_path_arg;
+        if (use_override) {
+            snprintf(apk_path_arg, sizeof(apk_path_arg), "%s", gmloader_config.apk_path.c_str());
+            argv_relaunch[arg_count++] = (char*)"-a";
+            argv_relaunch[arg_count++] = apk_path_arg;
+        }
+        argv_relaunch[arg_count] = nullptr;
+
+        warning("Main: Relaunching '%s' with apk_path='%s', save_dir='%s'\n", 
+                program_name, gmloader_config.apk_path.c_str(), gmloader_config.save_dir.c_str());
+        fflush(stdout);
+        fflush(stderr);
+        if (execv(program_name, argv_relaunch) == -1) {
+            fatal_error("Main: Failed to relaunch '%s': %s\n", program_name, strerror(errno));
+            return -1;
+        }
+    }
 
     return 0;
 }

--- a/gmloader/texture.cpp
+++ b/gmloader/texture.cpp
@@ -6,7 +6,6 @@
 #include "so_util.h"
 #include "io_util.h"
 #include "libyoyo.h"
-#include "configuration.h"
 
 #define STB_ONLY_PNG
 #include "stb_image.h"

--- a/gmloader/texture_arm32.cpp
+++ b/gmloader/texture_arm32.cpp
@@ -7,7 +7,6 @@
 #include "so_util.h"
 #include "platform.h"
 #include "libyoyo.h"
-#include "configuration.h"
 #include "texture.h"
 
 ABI_ATTR void LoadTextureFromPNG_1(uint32_t *texture, int has_mips) {

--- a/gmloader/texture_arm64.cpp
+++ b/gmloader/texture_arm64.cpp
@@ -7,7 +7,6 @@
 #include "so_util.h"
 #include "platform.h"
 #include "libyoyo.h"
-#include "configuration.h"
 #include "texture.h"
 
 ABI_ATTR void LoadTextureFromPNG_1(uintptr_t texture, int has_mips)


### PR DESCRIPTION
Add the `game_change` function reimplementation used in Deltarune to allow seamless swapping between included files while retaining the same savedir. Verified functional, requires one "apk" for each subgame.

Example:

Initial apk_path: `"apk_path" : "assets/deltarune",`

Contents of `deltarune/assets/*`:
```
    chapter1_windows
    chapter2_windows
    deltarune
```

They do not have a file extension but they are zip files. When `game_change()` passes arguments, we intercept it and thanks to our reimplementation, we change the `apk_path` to point to the `working_directory` that was passed i.e. `/chapter2_windows`. The new apk_path thus becomes `assets/chapter2_windows` which is essentially its own game, but uses shared resources from the `save_dir`. This mimics the intention on supported platforms.